### PR TITLE
Improve `ln2fill` abort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### ✨ Improved
 
+* [#23](https://github.com/sdss/lvmscp/pull/23) `ln2fill abort` now creates a lockfile in `/data/ln2fill.lock` that, if present, prevents new purges or fills. It can be removed with `ln2fill clear`.
+* [#23](https://github.com/sdss/lvmscp/pull/23) By default the pressure of the cryostats is checked before a purge or fill. If any camera is above the threshold the purge/fill is aborted.
 * Custom configuration is now merged with the default, internal configuration.
 * Clean-up how header keywords are compiled and how defaults are set.
 

--- a/python/lvmscp/ln2.py
+++ b/python/lvmscp/ln2.py
@@ -558,7 +558,7 @@ def check_lockfile():
 
     if LOCKFILE.exists():
         raise ValueError(
-            "Lock file found. Fills are not allowd. "
+            "Lock file found. Fills are not allowed. "
             "Use ln2fill clear to remove the lock."
         )
 

--- a/python/lvmscp/ln2.py
+++ b/python/lvmscp/ln2.py
@@ -32,7 +32,7 @@ PURGE_OUTLET = ("sp1", "purge")
 # Pressure above which we don't purge/fill.
 PRESSURE_LIMIT = 1e-3
 
-LOCKFILE = pathlib.Path("/home/sdss5/.config/ln2fill.lock")
+LOCKFILE = pathlib.Path("/data/ln2fill.lock")
 
 FD: io.StringIO | None = None
 


### PR DESCRIPTION
- `ln2fill abort` now creates a lockfile in `/data/ln2fill.lock` that, if present, prevents new purges or fills. It can be removed with `ln2fill clear`.
- By default the pressure of the cryostats is checked before a purge or fill and if any cameras is above the threshold, the purge/fill is aborted.